### PR TITLE
fix: Tailwind CSS build hangs during deployment

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "start": "node server.js",
     "dev": "nodemon server.js",
     "build": "npm run build:css",
-    "build:css": "tailwindcss -i ./public/css/input.css -o ./public/css/output.css --watch"
+    "build:css": "tailwindcss -i ./public/css/input.css -o ./public/css/output.css --minify",
+    "dev:css": "tailwindcss -i ./public/css/input.css -o ./public/css/output.css --watch"
   },
   "keywords": [
     "portfolio",


### PR DESCRIPTION
## Summary
- The `build:css` script used `--watch` which hangs forever during EC2 deployment
- Split into `build:css` (one-shot, minified) for production and `dev:css` (with --watch) for local dev
- This fixes the oversized icons — CSS was never being rebuilt on deploy

## Test plan
- [x] Verify `npm run build` exits cleanly
- [ ] Verify icons render at correct size after deployment

🤖 Generated with [Claude Code](https://claude.com/claude-code)